### PR TITLE
Fix image resizing upscale

### DIFF
--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -14,10 +14,10 @@ export const resizeImage = (file: File): Promise<Blob> => {
     img.onload = () => {
       const canvas = document.createElement('canvas');
       const MAX_WIDTH = 800;
-      const scaleSize = MAX_WIDTH / img.width;
+      const scale = img.width > MAX_WIDTH ? MAX_WIDTH / img.width : 1;
 
-      canvas.width = MAX_WIDTH;
-      canvas.height = img.height * scaleSize;
+      canvas.width = img.width * scale;
+      canvas.height = img.height * scale;
 
       const ctx = canvas.getContext('2d');
       if (!ctx) return reject('Canvas context 실패');


### PR DESCRIPTION
## Summary
- prevent upscaling small images during resize

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@emotion/react')*

------
https://chatgpt.com/codex/tasks/task_e_683ff075bb988328a04987b91a5b9106